### PR TITLE
Default alias feature

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,5 @@
 import { MarkdownView } from "obsidian";
-import { adjustCursor, getSelectedText } from "./utils";
+import { adjustCursor, getSelectedText, getDateLinkAlias } from "./utils";
 import NaturalLanguageDates from "./main";
 
 export function getParseCommand(plugin: NaturalLanguageDates, mode: string): void {
@@ -26,16 +26,19 @@ export function getParseCommand(plugin: NaturalLanguageDates, mode: string): voi
     return;
   }
 
-  //mode == "replace"
-  let newStr = `[[${date.formattedString}]]`;
+  let newStr;
 
-  if (mode == "link") {
+  if (mode == "replace") {
+    let alias = getDateLinkAlias(plugin, selectedText, false);
+    newStr = alias
+      ? `[[${date.formattedString}|${alias}]]`
+      : `[[${date.formattedString}]]`;
+  } else if (mode == "link") {
     newStr = `[${selectedText}](${date.formattedString})`;
   } else if (mode == "clean") {
     newStr = `${date.formattedString}`;
   } else if (mode == "time") {
     const time = plugin.parseTime(selectedText);
-
     newStr = `${time.formattedString}`;
   }
 

--- a/src/modals/date-picker.ts
+++ b/src/modals/date-picker.ts
@@ -1,5 +1,5 @@
 import { App, MarkdownView, Modal, Setting } from "obsidian";
-import { generateMarkdownLink } from "src/utils";
+import { generateMarkdownLink, getDateLinkAlias } from "src/utils";
 import type NaturalLanguageDates from "../main";
 
 export default class DatePickerModal extends Modal {
@@ -32,14 +32,7 @@ export default class DatePickerModal extends Modal {
         : "";
 
       if (insertAsLink) {
-        let alias: string | undefined = undefined;
-        if (shouldIncludeAlias) {
-          alias = cleanDateInput;
-        } else if (this.plugin.settings.defaultAlias) {
-          alias = parsedDate.moment.isValid()
-            ? parsedDate.moment.format(this.plugin.settings.defaultAlias)
-            : undefined;
-        }
+        const alias = getDateLinkAlias(this.plugin, cleanDateInput, shouldIncludeAlias);
         parsedDateString = generateMarkdownLink(
           this.app,
           parsedDateString,

--- a/src/modals/date-picker.ts
+++ b/src/modals/date-picker.ts
@@ -32,10 +32,18 @@ export default class DatePickerModal extends Modal {
         : "";
 
       if (insertAsLink) {
+        let alias: string | undefined = undefined;
+        if (shouldIncludeAlias) {
+          alias = cleanDateInput;
+        } else if (this.plugin.settings.defaultAlias) {
+          alias = parsedDate.moment.isValid()
+            ? parsedDate.moment.format(this.plugin.settings.defaultAlias)
+            : undefined;
+        }
         parsedDateString = generateMarkdownLink(
           this.app,
           parsedDateString,
-          shouldIncludeAlias ? cleanDateInput : undefined
+          alias
         );
       }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -19,6 +19,7 @@ export interface NLDSettings {
   appendTimeToDateWhenRelated: boolean;
 
   format: string;
+  defaultAlias: string;
   timeFormat: string;
   separator: string;
   weekStart: DayOfWeek;
@@ -35,6 +36,7 @@ export const DEFAULT_SETTINGS: NLDSettings = {
   appendTimeToDateWhenRelated: true,
 
   format: "YYYY-MM-DD",
+  defaultAlias: "",
   timeFormat: "HH:mm",
   separator: " ",
   weekStart: "locale-default",
@@ -181,5 +183,18 @@ export class NLDSettingsTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           })
       );
+
+    new Setting(containerEl)
+    .setName("Default alias for links")
+    .setDesc("Specify a time format as the default alias when creating wikilink dates. (default: none)")
+    .addText((text) =>
+      text
+        .setPlaceholder("dddd, MMMM Do YYYY")
+        .setValue(this.plugin.settings.defaultAlias)
+        .onChange(async (value) => {
+          this.plugin.settings.defaultAlias = value || "";
+          await this.plugin.saveSettings();
+        })
+    );
   }
 }

--- a/src/suggest/date-suggest.ts
+++ b/src/suggest/date-suggest.ts
@@ -108,10 +108,19 @@ export default class DateSuggest extends EditorSuggest<IDateCompletion> {
     }
 
     if (makeIntoLink) {
+      let alias: string | undefined = undefined;
+      if (includeAlias) {
+        alias = suggestion.label;
+      } else if (this.plugin.settings.defaultAlias) {
+        const parsed = this.plugin.parseDate(suggestion.label);
+        alias = parsed.moment.isValid()
+          ? parsed.moment.format(this.plugin.settings.defaultAlias)
+          : undefined;
+      }
       dateStr = generateMarkdownLink(
         this.app,
         dateStr,
-        includeAlias ? suggestion.label : undefined
+        alias
       );
     }
 

--- a/src/suggest/date-suggest.ts
+++ b/src/suggest/date-suggest.ts
@@ -7,7 +7,7 @@ import {
   EditorSuggestTriggerInfo
 } from "obsidian";
 import type NaturalLanguageDates from "src/main";
-import { generateMarkdownLink } from "src/utils";
+import { generateMarkdownLink, getDateLinkAlias } from "src/utils";
 
 interface IDateCompletion {
   label: string;
@@ -108,15 +108,7 @@ export default class DateSuggest extends EditorSuggest<IDateCompletion> {
     }
 
     if (makeIntoLink) {
-      let alias: string | undefined = undefined;
-      if (includeAlias) {
-        alias = suggestion.label;
-      } else if (this.plugin.settings.defaultAlias) {
-        const parsed = this.plugin.parseDate(suggestion.label);
-        alias = parsed.moment.isValid()
-          ? parsed.moment.format(this.plugin.settings.defaultAlias)
-          : undefined;
-      }
+      const alias = getDateLinkAlias(this.plugin, suggestion.label, includeAlias);
       dateStr = generateMarkdownLink(
         this.app,
         dateStr,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -153,6 +153,23 @@ export function generateMarkdownLink(app: App, subpath: string, alias?: string) 
   // return app.fileManager.generateMarkdownLink(file, "", undefined, alias);
 // }
 
+export function getDateLinkAlias(
+  plugin: { settings: { defaultAlias: string }, parseDate: (s: string) => { moment: moment.Moment } },
+  dateInput: string,
+  useSuggestionLabel: boolean
+): string | undefined {
+  if (useSuggestionLabel) {
+    return dateInput;
+  }
+  if (plugin.settings.defaultAlias) {
+    const parsed = plugin.parseDate(dateInput);
+    return parsed.moment.isValid()
+      ? parsed.moment.format(plugin.settings.defaultAlias)
+      : undefined;
+  }
+  return undefined;
+}
+
 export async function getOrCreateDailyNote(date: Moment): Promise<TFile | null> {
   // Borrowed from the Slated plugin:
   // https://github.com/tgrosinger/slated-obsidian/blob/main/src/vault.ts#L17


### PR DESCRIPTION
New setting: Specify a time format as the default alias when creating wikilink dates.

This was technically possible previously by inputting an escaped pipe into the main format, e.g. YYYY-MM-DD\\|dddd, MMMM Do YYYY

But this would break when holding shift on the auto-suggest prompt to keep the suggested text as an alias.