### PR TITLE
Feature: Open daily note using natural language

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ It's now possible to use the [Obsidian URI](https://publish.obsidian.md/help/Adv
 
 Opens the date picker menu
 
+#### Natural Language Dates: Open daily note using natural language
+
+Input a natural language date to open or create the daily note for the parsed date.
+
 #### Other Commands
 
 | Setting                                     | Description                                                                                                                                                                                                                                                                                                                                                                       | Default                       |

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import {
   getNowCommand,
 } from "./commands";
 import { getFormattedDate, getOrCreateDailyNote, parseTruthy } from "./utils";
+import { OpenDailyNoteModal } from "./modals/open-daily-note";
 
 export default class NaturalLanguageDates extends Plugin {
   private parser: NLDParser;
@@ -70,6 +71,15 @@ export default class NaturalLanguageDates extends Plugin {
         }
         new DatePickerModal(this.app, this).open();
       }
+    });
+
+    this.addCommand({
+      id: "nlp-open-daily-note",
+      name: "Open daily note using natural language",
+      callback: () => {
+        const modal = new OpenDailyNoteModal(this.app, this);
+        modal.open();
+      },
     });
 
     this.addSettingTab(new NLDSettingsTab(this.app, this));

--- a/src/modals/open-daily-note.ts
+++ b/src/modals/open-daily-note.ts
@@ -1,0 +1,39 @@
+import { Notice, SuggestModal, App } from "obsidian";
+import { getOrCreateDailyNote } from "../utils";
+import type NaturalLanguageDates from "../main";
+import DateSuggest from "../suggest/date-suggest";
+
+// Credit: https://github.com/charliecm/obsidian-open-with-nldates
+export class OpenDailyNoteModal extends SuggestModal<string> {
+  plugin: NaturalLanguageDates;
+
+  constructor(app: App, plugin: NaturalLanguageDates) {
+    super(app);
+    this.plugin = plugin;
+  }
+
+  getSuggestions(query: string): string[] {
+    const tempSuggest = new DateSuggest(this.app, this.plugin);
+    const suggestions = tempSuggest.getDateSuggestions(
+      { query },
+      ['Today', 'Yesterday', 'Tomorrow']
+    );
+    return suggestions.map(s => s.label).length ? suggestions.map(s => s.label) : [query];
+  }
+
+  renderSuggestion(suggestion: string, el: HTMLElement) {
+    el.createEl("div", { text: suggestion });
+  }
+
+  async onChooseSuggestion(suggestion: string) {
+    const parsedDate = this.plugin.parseDate(suggestion);
+    const date = parsedDate.moment;
+    if (!parsedDate.date || !date.isValid()) {
+      new Notice("Unable to parse date");
+      return;
+    }
+
+    const note = await getOrCreateDailyNote(date);
+    this.app.workspace.getLeaf().openFile(note);
+  }
+}

--- a/src/suggest/date-suggest.ts
+++ b/src/suggest/date-suggest.ts
@@ -43,7 +43,10 @@ export default class DateSuggest extends EditorSuggest<IDateCompletion> {
     return [{ label: context.query }];
   }
 
-  getDateSuggestions(context: EditorSuggestContext): IDateCompletion[] {
+  getDateSuggestions(
+    context: EditorSuggestContext | { query: string },
+    defaults: string[] = ["Now", "Today", "Yesterday", "Tomorrow", "In 1 hour", "1 hour ago"]
+  ): IDateCompletion[] {
     if (context.query.match(/^time/)) {
       return ["now", "+15 minutes", "+1 hour", "-15 minutes", "-1 hour"]
         .map((val) => ({ label: `time:${val}` }))
@@ -83,9 +86,9 @@ export default class DateSuggest extends EditorSuggest<IDateCompletion> {
       ].filter((items) => items.label.toLowerCase().startsWith(context.query));
     }
 
-    return [{ label: "Now" }, { label: "Today" }, { label: "Yesterday" }, { label: "Tomorrow" }, { label: "In 1 hour"}, { label: "1 hour ago" }].filter(
-      (items) => items.label.toLowerCase().startsWith(context.query)
-    );
+    return defaults
+      .map((label) => ({ label }))
+      .filter((items) => items.label.toLowerCase().startsWith(context.query));
   }
 
   renderSuggestion(suggestion: IDateCompletion, el: HTMLElement): void {


### PR DESCRIPTION
Credit to https://github.com/charliecm/obsidian-open-with-nldates

Open a modal dialogue where you can input a natural language date to open that specific daily note.

I think this feature should be part of the main plugin, it's extremely useful and makes sense.